### PR TITLE
feat: add basic LLM CLI agent (task 1)

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -1,0 +1,16 @@
+# Agent: CLI interface to LLM
+
+## Overview
+`agent.py` is a command line that takes a user question, sends it to a large language model via an OpenAI-compatible API, and returns a structured response in JSON format.
+
+## Requirements
+- Python 3.10+
+- `uv` for dependency management
+- Access to LLM via API (default: local Qwen Code proxy)
+
+## Configuration
+
+### 1. Running the proxy (if using local Qwen)
+```bash
+cd ~/qwen-code-oai-proxy
+docker compose up -d

--- a/agent.py
+++ b/agent.py
@@ -1,0 +1,114 @@
+"""
+CLI-агент для вызова LLM через OpenAI-compatible API.
+Принимает вопрос, возвращает структурированный JSON ответ.
+"""
+
+import json
+import os
+import sys
+import argparse
+from pathlib import Path
+
+# Используем httpx для async-запросов с таймаутом
+try:
+    import httpx
+except ImportError:
+    print("Ошибка: требуется пакет httpx. Установите: uv add httpx", file=sys.stderr)
+    sys.exit(1)
+
+
+def load_env_file(filepath: str) -> dict:
+    """Загружает переменные окружения из .env файла."""
+    env_vars = {}
+    path = Path(filepath)
+    if not path.exists():
+        print(f"Предупреждение: файл {filepath} не найден", file=sys.stderr)
+        return env_vars
+    
+    with open(path, "r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            key, value = line.split("=", 1)
+            env_vars[key.strip()] = value.strip().strip('"\'')
+    return env_vars
+
+
+def call_llm(question: str, config: dict) -> dict:
+    """Отправляет запрос к LLM и возвращает ответ."""
+    api_base = config.get("LLM_API_BASE", "http://localhost:42005/v1")
+    api_key = config.get("LLM_API_KEY", "")
+    model = config.get("LLM_MODEL", "qwen3-coder-plus")
+    timeout = int(config.get("LLM_TIMEOUT", "60"))
+    
+    # Формируем системный промпт (минимальный для задачи 1)
+    system_prompt = (
+        "Ты полезный ассистент. Отвечай кратко и точно на вопросы пользователя. "
+        "Форматируй ответ как обычный текст, без маркдауна."
+    )
+    
+    headers = {
+        "Content-Type": "application/json",
+        "Authorization": f"Bearer {api_key}"
+    }
+    
+    payload = {
+        "model": model,
+        "messages": [
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": question}
+        ],
+        "temperature": 0.1,
+        "max_tokens": 500
+    }
+    
+    url = f"{api_base}/chat/completions"
+    
+    try:
+        print(f"Отправка запроса к {url}...", file=sys.stderr)
+        
+        with httpx.Client(timeout=timeout) as client:
+            response = client.post(url, headers=headers, json=payload)
+            response.raise_for_status()
+            data = response.json()
+        
+        # Извлекаем ответ из структуры OpenAI
+        if "choices" in data and len(data["choices"]) > 0:
+            answer = data["choices"][0]["message"]["content"]
+        else:
+            raise ValueError("Неожиданная структура ответа от LLM")
+        
+        return {"ответ": answer.strip(), "вызовы_инструмента": []}
+        
+    except httpx.TimeoutException:
+        print(f"Ошибка: таймаут запроса ({timeout}с)", file=sys.stderr)
+        sys.exit(1)
+    except httpx.RequestError as e:
+        print(f"Ошибка сети: {e}", file=sys.stderr)
+        sys.exit(1)
+    except Exception as e:
+        print(f"Ошибка обработки ответа: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="CLI-агент для вызова LLM")
+    parser.add_argument("question", type=str, help="Вопрос для агента")
+    args = parser.parse_args()
+    
+    # Загружаем конфигурацию
+    config = load_env_file(".env.agent.secret")
+    
+    # Вызываем LLM
+    result = call_llm(args.question, config)
+    
+    # Выводим ТОЛЬКО валидный JSON в stdout
+    print(json.dumps(result, ensure_ascii=False))
+    
+    # Успешный выход
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/plans/task-1.md
+++ b/plans/task-1.md
@@ -1,0 +1,25 @@
+# Task Plan 1: Basic CLI Agent
+
+## Selecting a provider and model
+- **Provider**: Qwen Code via a local proxy (`qwen-code-oai-proxy`)
+- **Endpoint**: `http://localhost:42005/v1`
+- **Model**: `qwen3-coder-plus`
+- **Authentication**: Bearer token from `.env.agent.secret`
+
+## Agent Architecture
+## agent.py structure
+1. Parsing command line arguments (question)
+2. Loading configuration from `.env.agent.secret`
+3. Forming a request to OpenAI-compatible API
+4. Sending a POST request with a timeout of 60 seconds
+5. Parsing the response, extracting `content`
+6. Forming JSON: `{"response": "...", "tool_calls": []}`
+7. Output to stdout, logs to stderr
+
+## Error handling
+- Network errors → output to stderr, exit code 1
+- Timeout → output to stderr, exit code 1
+- Invalid response from LLM → output to stderr, exit code 1
+
+## Testing
+- One regression test: running agent.py, checking JSON in stdout

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -1,0 +1,68 @@
+"""
+Регрессионный тест для agent.py
+Проверяет, что агент возвращает валидный JSON с обязательными полями.
+"""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_agent_basic_response():
+    """Тест: агент отвечает на простой вопрос."""
+    
+    # Путь к agent.py относительно корня проекта
+    project_root = Path(__file__).parent.parent
+    agent_path = project_root / "agent.py"
+    
+    # Команда запуска
+    cmd = [
+        "uv", "run",
+        str(agent_path),
+        "Что такое Python?"
+    ]
+    
+    # Запускаем агент как подпроцесс
+    result = subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+        cwd=project_root,
+        timeout=70  # 60с + запас
+    )
+    
+    # Проверяем код выхода
+    assert result.returncode == 0, f"Агент вернул код {result.returncode}\nstderr: {result.stderr}"
+    
+    # Парсим stdout как JSON
+    try:
+        output = json.loads(result.stdout.strip())
+    except json.JSONDecodeError as e:
+        raise AssertionError(f"stdout не является валидным JSON: {e}\nstdout: {result.stdout}")
+    
+    # Проверяем обязательные поля
+    assert "ответ" in output, f"Отсутствует поле 'ответ' в ответе: {output}"
+    assert "вызовы_инструмента" in output, f"Отсутствует поле 'вызовы_инструмента' в ответе: {output}"
+    
+    # Проверяем тип tool_calls
+    assert isinstance(output["вызовы_инструмента"], list), "Поле 'вызовы_инструмента' должно быть массивом"
+    
+    # Проверяем, что ответ не пустой
+    assert len(output["ответ"]) > 0, "Поле 'ответ' не должно быть пустым"
+    
+    print("✅ Тест пройден", file=sys.stderr)
+    return True
+
+
+if __name__ == "__main__":
+    try:
+        test_agent_basic_response()
+        print("Все тесты пройдены!")
+        sys.exit(0)
+    except AssertionError as e:
+        print(f"❌ Тест провален: {e}", file=sys.stderr)
+        sys.exit(1)
+    except Exception as e:
+        print(f"❌ Ошибка выполнения теста: {e}", file=sys.stderr)
+        sys.exit(1)


### PR DESCRIPTION
- Create agent.py: CLI tool that calls LLM via OpenAI-compatible API
- Add AGENT.md: documentation for setup and usage
- Add plans/task-1.md: implementation plan
- Add tests/test_agent.py: regression test for JSON output
- Configure .env.agent.example for LLM settings

Agent accepts question as CLI arg, returns structured JSON: {"ответ": "...", "вызовы_инструмента": []}

Uses local qwen-code-oai-proxy at http://localhost:42005/v1

<!-- Provide a general summary of your changes in the Title above -->

## Summary

<!-- What does this PR do?

Replace <issue-number> with the number of the corresponding task issue.

Add more details if necessary.
-->

- Closes #1 

---

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I made this PR to the `main` branch **of my fork (NOT the course instructors' repo)**.
- [x] I see `base: main` <- `compare: <branch>` above the PR title.
- [x] I edited the line `- Closes #<issue-number>`.
- [x] I wrote clear commit messages.
- [x] I reviewed my own diff before requesting review.
- [x] I understand the changes I’m submitting.
