### PR TITLE
feat: add documentation agent with tool calling (task 2)

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -14,3 +14,12 @@
 ```bash
 cd ~/qwen-code-oai-proxy
 docker compose up -d
+# Documentation Agent CLI
+
+## Overview
+`agent.py` answers questions using LLM with tool calling (`read_file`, `list_files`).
+
+## Setup
+```bash
+cp .env.agent.example .env.agent.secret
+uv sync

--- a/agent.py
+++ b/agent.py
@@ -1,30 +1,121 @@
 """
-CLI-агент для вызова LLM через OpenAI-compatible API.
-Принимает вопрос, возвращает структурированный JSON ответ.
+Documentation Agent CLI - Task 2
+Answers questions using LLM with tool calling (read_file, list_files).
 """
 
 import json
 import os
 import sys
 import argparse
+import re
 from pathlib import Path
+from typing import Optional
 
-# Используем httpx для async-запросов с таймаутом
 try:
     import httpx
 except ImportError:
-    print("Ошибка: требуется пакет httpx. Установите: uv add httpx", file=sys.stderr)
+    print("Error: httpx required. Install: uv add httpx", file=sys.stderr)
     sys.exit(1)
 
+PROJECT_ROOT = Path(__file__).parent.resolve()
+MAX_TOOL_CALLS = 10
+DEFAULT_TIMEOUT = 60
+
+
+# =============================================================================
+# Tool Definitions
+# =============================================================================
+
+def get_tool_schemas() -> list[dict]:
+    """Return OpenAI-compatible function schemas."""
+    return [
+        {
+            "name": "read_file",
+            "description": "Read content of a file from the project",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "path": {
+                        "type": "string",
+                        "description": "Relative path from project root"
+                    }
+                },
+                "required": ["path"],
+                "additionalProperties": False
+            }
+        },
+        {
+            "name": "list_files",
+            "description": "List files and directories at a path",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "path": {
+                        "type": "string",
+                        "description": "Relative directory path from project root"
+                    }
+                },
+                "required": ["path"],
+                "additionalProperties": False
+            }
+        }
+    ]
+
+
+def _validate_path(path_str: str) -> Path:
+    """Validate path stays within PROJECT_ROOT."""
+    clean_path = path_str.strip().lstrip('/')
+    resolved = (PROJECT_ROOT / clean_path).resolve()
+    try:
+        resolved.relative_to(PROJECT_ROOT)
+    except ValueError:
+        raise ValueError(f"Path traversal detected: '{path_str}'")
+    return resolved
+
+
+def read_file(path: str) -> str:
+    """Read file content."""
+    try:
+        file_path = _validate_path(path)
+        if not file_path.is_file():
+            return f"Error: File not found: {path}"
+        return file_path.read_text(encoding="utf-8")
+    except ValueError as e:
+        return f"Error: {e}"
+    except Exception as e:
+        return f"Error: {type(e).__name__}: {e}"
+
+
+def list_files(path: str) -> str:
+    """List directory contents."""
+    try:
+        dir_path = _validate_path(path)
+        if not dir_path.is_dir():
+            return f"Error: Not a directory: {path}"
+        entries = []
+        for entry in sorted(dir_path.iterdir()):
+            suffix = "/" if entry.is_dir() else ""
+            entries.append(f"{entry.name}{suffix}")
+        return "\n".join(entries)
+    except ValueError as e:
+        return f"Error: {e}"
+    except Exception as e:
+        return f"Error: {type(e).__name__}: {e}"
+
+
+TOOLS = {"read_file": read_file, "list_files": list_files}
+
+
+# =============================================================================
+# LLM Communication
+# =============================================================================
 
 def load_env_file(filepath: str) -> dict:
-    """Загружает переменные окружения из .env файла."""
+    """Load environment variables from .env file."""
     env_vars = {}
     path = Path(filepath)
     if not path.exists():
-        print(f"Предупреждение: файл {filepath} не найден", file=sys.stderr)
         return env_vars
-    
     with open(path, "r", encoding="utf-8") as f:
         for line in f:
             line = line.strip()
@@ -35,78 +126,115 @@ def load_env_file(filepath: str) -> dict:
     return env_vars
 
 
-def call_llm(question: str, config: dict) -> dict:
-    """Отправляет запрос к LLM и возвращает ответ."""
+def call_llm(messages: list[dict], config: dict, tools: Optional[list[dict]] = None) -> dict:
+    """Send request to LLM API."""
     api_base = config.get("LLM_API_BASE", "http://localhost:42005/v1")
     api_key = config.get("LLM_API_KEY", "")
     model = config.get("LLM_MODEL", "qwen3-coder-plus")
-    timeout = int(config.get("LLM_TIMEOUT", "60"))
+    timeout = int(config.get("LLM_TIMEOUT", str(DEFAULT_TIMEOUT)))
     
-    # Формируем системный промпт (минимальный для задачи 1)
-    system_prompt = (
-        "Ты полезный ассистент. Отвечай кратко и точно на вопросы пользователя. "
-        "Форматируй ответ как обычный текст, без маркдауна."
-    )
+    headers = {"Content-Type": "application/json", "Authorization": f"Bearer {api_key}"}
+    payload = {"model": model, "messages": messages, "temperature": 0.1, "max_tokens": 1000}
     
-    headers = {
-        "Content-Type": "application/json",
-        "Authorization": f"Bearer {api_key}"
-    }
-    
-    payload = {
-        "model": model,
-        "messages": [
-            {"role": "system", "content": system_prompt},
-            {"role": "user", "content": question}
-        ],
-        "temperature": 0.1,
-        "max_tokens": 500
-    }
+    if tools:
+        payload["tools"] = tools
+        payload["tool_choice"] = "auto"
     
     url = f"{api_base}/chat/completions"
     
-    try:
-        print(f"Отправка запроса к {url}...", file=sys.stderr)
-        
-        with httpx.Client(timeout=timeout) as client:
-            response = client.post(url, headers=headers, json=payload)
-            response.raise_for_status()
-            data = response.json()
-        
-        # Извлекаем ответ из структуры OpenAI
-        if "choices" in data and len(data["choices"]) > 0:
-            answer = data["choices"][0]["message"]["content"]
-        else:
-            raise ValueError("Неожиданная структура ответа от LLM")
-        
-        return {"ответ": answer.strip(), "вызовы_инструмента": []}
-        
-    except httpx.TimeoutException:
-        print(f"Ошибка: таймаут запроса ({timeout}с)", file=sys.stderr)
-        sys.exit(1)
-    except httpx.RequestError as e:
-        print(f"Ошибка сети: {e}", file=sys.stderr)
-        sys.exit(1)
-    except Exception as e:
-        print(f"Ошибка обработки ответа: {e}", file=sys.stderr)
-        sys.exit(1)
+    with httpx.Client(timeout=timeout) as client:
+        response = client.post(url, headers=headers, json=payload)
+        response.raise_for_status()
+        return response.json()
 
+
+# =============================================================================
+# Agent Loop
+# =============================================================================
+
+def run_agent_loop(question: str, config: dict) -> dict:
+    """Run agent loop with tool calling."""
+    system_prompt = (
+        "You are a documentation assistant. Answer questions using the project wiki. "
+        "Use these tools:\n"
+        "- list_files(path): List directory contents\n"
+        "- read_file(path): Read file content\n\n"
+        "Rules:\n"
+        "1. Explore wiki/ directory with list_files if needed\n"
+        "2. Use read_file to get content from specific files\n"
+        "3. Cite source as: wiki/filename.md#section-anchor\n"
+        "4. Return answer in JSON format"
+    )
+    
+    messages = [
+        {"role": "system", "content": system_prompt},
+        {"role": "user", "content": question}
+    ]
+    
+    tool_schemas = get_tool_schemas()
+    tool_calls_log = []
+    
+    for iteration in range(MAX_TOOL_CALLS):
+        try:
+            response = call_llm(messages, config, tools=tool_schemas)
+        except Exception as e:
+            return {"answer": f"Error: LLM call failed: {e}", "source": "", "tool_calls": tool_calls_log}
+        
+        choice = response.get("choices", [{}])[0]
+        message = choice.get("message", {})
+        tool_calls = message.get("tool_calls", [])
+        
+        if tool_calls:
+            for tool_call in tool_calls:
+                tool_name = tool_call.get("function", {}).get("name")
+                tool_args_str = tool_call.get("function", {}).get("arguments", "{}")
+                
+                try:
+                    tool_args = json.loads(tool_args_str) if isinstance(tool_args_str, str) else tool_args_str
+                except json.JSONDecodeError:
+                    tool_args = {}
+                
+                if tool_name in TOOLS:
+                    try:
+                        result = TOOLS[tool_name](**tool_args)
+                    except Exception as e:
+                        result = f"Error: {type(e).__name__}: {e}"
+                else:
+                    result = f"Error: Unknown tool '{tool_name}'"
+                
+                tool_calls_log.append({"tool": tool_name, "args": tool_args, "result": result})
+                
+                messages.append({
+                    "role": "tool",
+                    "tool_call_id": tool_call.get("id", ""),
+                    "content": result,
+                    "name": tool_name
+                })
+            continue
+        else:
+            answer = message.get("content", "")
+            source = ""
+            match = re.search(r'(wiki/[\w\-/]+\.md(?:#[\w\-]+)?)', answer)
+            if match:
+                source = match.group(1)
+            
+            return {"answer": answer.strip(), "source": source, "tool_calls": tool_calls_log}
+    
+    return {"answer": "Error: Max tool calls reached", "source": "", "tool_calls": tool_calls_log}
+
+
+# =============================================================================
+# Main
+# =============================================================================
 
 def main():
-    parser = argparse.ArgumentParser(description="CLI-агент для вызова LLM")
-    parser.add_argument("question", type=str, help="Вопрос для агента")
+    parser = argparse.ArgumentParser(description="Documentation Agent CLI")
+    parser.add_argument("question", type=str, help="Question to ask")
     args = parser.parse_args()
     
-    # Загружаем конфигурацию
     config = load_env_file(".env.agent.secret")
-    
-    # Вызываем LLM
-    result = call_llm(args.question, config)
-    
-    # Выводим ТОЛЬКО валидный JSON в stdout
+    result = run_agent_loop(args.question, config)
     print(json.dumps(result, ensure_ascii=False))
-    
-    # Успешный выход
     sys.exit(0)
 
 

--- a/plans/task-2.md
+++ b/plans/task-2.md
@@ -1,0 +1,26 @@
+# Task 2 Plan: Documentation Agent
+
+## Tool Schemas
+
+### read_file
+- **Parameters:** `path` (string) — relative path from project root
+- **Returns:** File content or error message
+- **Security:** Reject paths outside project root (no ../ traversal)
+
+### list_files
+- **Parameters:** `path` (string) — relative directory path
+- **Returns:** Newline-separated list of files/directories
+- **Security:** Same path validation as read_file
+
+## Agent Loop
+1. Send question + tool schemas to LLM
+2. If `tool_calls` in response → execute tools, add results, repeat (max 10 iterations)
+3. If text response → extract answer + source, return JSON
+
+## Output Format
+```json
+{
+  "answer": "string",
+  "source": "wiki/file.md#anchor",
+  "tool_calls": [{"tool": "...", "args": {}, "result": "..."}]
+}

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -1,7 +1,4 @@
-"""
-Регрессионный тест для agent.py
-Проверяет, что агент возвращает валидный JSON с обязательными полями.
-"""
+"""Regression tests for Documentation Agent (Task 2)."""
 
 import json
 import subprocess
@@ -9,60 +6,53 @@ import sys
 from pathlib import Path
 
 
-def test_agent_basic_response():
-    """Тест: агент отвечает на простой вопрос."""
-    
-    # Путь к agent.py относительно корня проекта
+def run_agent(question: str) -> tuple[int, str, str]:
+    """Run agent.py and return (returncode, stdout, stderr)."""
     project_root = Path(__file__).parent.parent
-    agent_path = project_root / "agent.py"
+    cmd = ["uv", "run", str(project_root / "agent.py"), question]
+    result = subprocess.run(cmd, capture_output=True, text=True, cwd=project_root, timeout=70)
+    return result.returncode, result.stdout.strip(), result.stderr
+
+
+def test_wiki_question_with_read_file():
+    """Test: Question about wiki expects read_file in tool_calls."""
+    returncode, stdout, stderr = run_agent("What files are in the wiki directory?")
+    assert returncode == 0, f"Agent failed: {stderr}"
     
-    # Команда запуска
-    cmd = [
-        "uv", "run",
-        str(agent_path),
-        "Что такое Python?"
-    ]
+    output = json.loads(stdout)
+    assert "answer" in output
+    assert "source" in output
+    assert "tool_calls" in output
+    assert len(output["tool_calls"]) > 0, "Expected tool calls"
     
-    # Запускаем агент как подпроцесс
-    result = subprocess.run(
-        cmd,
-        capture_output=True,
-        text=True,
-        cwd=project_root,
-        timeout=70  # 60с + запас
-    )
+    tools_used = [c["tool"] for c in output["tool_calls"]]
+    assert "list_files" in tools_used or "read_file" in tools_used, f"Expected list_files or read_file, got: {tools_used}"
     
-    # Проверяем код выхода
-    assert result.returncode == 0, f"Агент вернул код {result.returncode}\nstderr: {result.stderr}"
+    print("✓ test_wiki_question_with_read_file passed", file=sys.stderr)
+
+
+def test_wiki_files_question_with_list_files():
+    """Test: Question about files expects list_files in tool_calls."""
+    returncode, stdout, stderr = run_agent("List all files in wiki")
+    assert returncode == 0, f"Agent failed: {stderr}"
     
-    # Парсим stdout как JSON
-    try:
-        output = json.loads(result.stdout.strip())
-    except json.JSONDecodeError as e:
-        raise AssertionError(f"stdout не является валидным JSON: {e}\nstdout: {result.stdout}")
+    output = json.loads(stdout)
+    assert "answer" in output
+    assert "tool_calls" in output
+    assert len(output["tool_calls"]) > 0, "Expected tool calls"
     
-    # Проверяем обязательные поля
-    assert "ответ" in output, f"Отсутствует поле 'ответ' в ответе: {output}"
-    assert "вызовы_инструмента" in output, f"Отсутствует поле 'вызовы_инструмента' в ответе: {output}"
+    tools_used = [c["tool"] for c in output["tool_calls"]]
+    assert "list_files" in tools_used, f"Expected list_files, got: {tools_used}"
     
-    # Проверяем тип tool_calls
-    assert isinstance(output["вызовы_инструмента"], list), "Поле 'вызовы_инструмента' должно быть массивом"
-    
-    # Проверяем, что ответ не пустой
-    assert len(output["ответ"]) > 0, "Поле 'ответ' не должно быть пустым"
-    
-    print("✅ Тест пройден", file=sys.stderr)
-    return True
+    print("✓ test_wiki_files_question_with_list_files passed", file=sys.stderr)
 
 
 if __name__ == "__main__":
     try:
-        test_agent_basic_response()
-        print("Все тесты пройдены!")
+        test_wiki_question_with_read_file()
+        test_wiki_files_question_with_list_files()
+        print("All tests passed!", file=sys.stderr)
         sys.exit(0)
     except AssertionError as e:
-        print(f"❌ Тест провален: {e}", file=sys.stderr)
-        sys.exit(1)
-    except Exception as e:
-        print(f"❌ Ошибка выполнения теста: {e}", file=sys.stderr)
+        print(f"Test failed: {e}", file=sys.stderr)
         sys.exit(1)


### PR DESCRIPTION
- Implement read_file and list_files tools
- Add agent loop with max 10 iterations
- Output: answer, source, tool_calls
- Add 2 regression tests
- Path security: no directory traversal

Closes #2

<!-- Provide a general summary of your changes in the Title above -->

## Summary

<!-- What does this PR do?

Replace <issue-number> with the number of the corresponding task issue.

Add more details if necessary.
-->

- Closes #3 

---

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I made this PR to the `main` branch **of my fork (NOT the course instructors' repo)**.
- [x] I see `base: main` <- `compare: <branch>` above the PR title.
- [x] I edited the line `- Closes #<issue-number>`.
- [x] I wrote clear commit messages.
- [x] I reviewed my own diff before requesting review.
- [x] I understand the changes I’m submitting.
